### PR TITLE
A realistic way of funding an attacker's account when testing

### DIFF
--- a/src/log/Log.sol
+++ b/src/log/Log.sol
@@ -11,9 +11,8 @@ abstract contract Log {
     }
 
     // Enum defining different phases for logging
-    enum LogPhase
-    // Default phase
-    {
+    enum LogPhase {
+        // Default phase
         DEFAULT,
         // Log messages from the "Initiate Attack" phase
         INITIALIZE_ATTACK,
@@ -35,9 +34,8 @@ abstract contract Log {
     }
 
     // Enum defining different types of logs
-    enum LogType
-    // Log everything
-    {
+    enum LogType {
+        // Log everything
         ALL,
         // Log messages from the "Initiate Attack" phase
         INITIALIZE_ATTACK,

--- a/src/tokens/README.md
+++ b/src/tokens/README.md
@@ -339,11 +339,15 @@ This template is for getting started with manipulating token balances. The token
 
 ## Usage
 
-The following attack contract demonstrate a simple token balance manipulation of USDC on a fork of Ethereum mainnet.
+The following attack contract demonstrates a simple token balance manipulation of USDC on a fork of Ethereum mainnet.
 
 * [TokenExampleManipulation](./examples/TokenExampleManipulation.sol)
 
-Extend the Tokens contract and call `deal(IERC20 token, address to, uint256 amount)` to set an accounts balance for the specified token:
+Extend the Tokens contract to set an account balance for the specified token or to transfer tokens from one address to another:
 ```
+// Modify the account balance for the specified token
 deal(EthereumTokens.USDC, address(this), 1 ether);
+
+// Impersonate the address 'user' with a prank call and transfer tokens from 'user' to 'address(this)' using the token's IERC20 interface
+dealFrom(EthereumTokens.USDC, user, address(this), 1 ether);
 ```

--- a/src/tokens/README.md
+++ b/src/tokens/README.md
@@ -343,7 +343,7 @@ The following attack contract demonstrates a simple token balance manipulation o
 
 * [TokenExampleManipulation](./examples/TokenExampleManipulation.sol)
 
-Extend the Tokens contract to set an account balance for the specified token or to transfer tokens from one address to another:
+Extend the Tokens contract to set an accounts balance for the specified token or to transfer tokens from one address to another:
 ```
 // Modify the account balance for the specified token
 deal(EthereumTokens.USDC, address(this), 1 ether);

--- a/src/tokens/Tokens.sol
+++ b/src/tokens/Tokens.sol
@@ -18,6 +18,18 @@ abstract contract Tokens is Test {
             deal(address(token), to, amount);
         }
     }
+
+    /**
+     * @notice Transfers tokens from one address to another using a Prank call.
+     * @param token The IERC20 token to transfer.
+     * @param from The address to transfer tokens from.
+     * @param to The address to transfer tokens to.
+     * @param amount The amount of tokens to transfer.
+     */
+    function dealFrom(IERC20 token, address from, address to, uint256 amount) public {
+        vm.prank(from);
+        token.transfer(to, amount);
+    }
 }
 
 library EthereumTokens {


### PR DESCRIPTION
Fixes #33 

## Vulnerability Type
To avoid discovering false-positives, and promote the use of "good practices" within the web3 whitehat community, we are adding to **Forge POC Templates** the `dealFrom( token, from, to, amount )` cheat-code, which impersonates the user `from` using the `prank` cheat-code and does a normal transfer with `token.transfer(to, amount)`.

This is the most realistic way of funding an attacker's balance while testing a system or creating a proof of concept.

## Usage
```solidity
IERC20 seBNB = IERC20(address(0x7e844423510A5081DE839e600F7960C7cE84eb82));

// Fund the attacker's account by transferring 10000000000000 seBNB from 0xfFc71114ea324a452da7B5a0Bc17fa1F13a327Ac
dealFrom(seBNB, address(0xfFc71114ea324a452da7B5a0Bc17fa1F13a327Ac), address(attackContract), 10000000000000);
```

#### PR Checklist
- [ ] Attack Template
- [ ] Attack Example
- [ ] Test
- [ ] Readme Updated