### PR TITLE
Removed AAVE and Euler tests due to flash loan functionality deprecation

### DIFF
--- a/src/flashloan/README.md
+++ b/src/flashloan/README.md
@@ -9,10 +9,10 @@ This template is for getting started with attack PoCs which use flash loans. The
 
 | Network | Protocol | Library |
 | ---------- | -------- | ------------------------------------------------------- |
-| Ethereum | AAVEV1     | [AAVEV1FlashLoan](./lib/AAVEV1FlashLoan.sol) |
+| Ethereum | AAVEV1 ⚠️     | [AAVEV1FlashLoan](./lib/AAVEV1FlashLoan.sol) |
 | Ethereum | AAVEV2     | [AAVEV2FlashLoan](./lib/AAVEV2FlashLoan.sol) |
 | Ethereum | AAVEV3     | [AAVEV3FlashLoan](./lib/AAVEV3FlashLoan.sol) |
-| Ethereum | Euler      | [EulerFlashLoan](./lib/EulerFlashLoan.sol) |
+| Ethereum | Euler ⚠️     | [EulerFlashLoan](./lib/EulerFlashLoan.sol) |
 | Ethereum | Balancer   | [BalancerFlashLoan](./lib/BalancerFlashLoan.sol) |
 | Ethereum | MakerDAO   | [MakerDAOFlashLoan](./lib/MakerDAOFlashLoan.sol) |
 | Ethereum | UniswapV2  | [UniswapV2FlashLoan](./lib/UniswapV2FlashLoan.sol) |

--- a/src/flashloan/examples/MultiProviderFlashLoanExample.sol
+++ b/src/flashloan/examples/MultiProviderFlashLoanExample.sol
@@ -15,8 +15,8 @@ contract MultiProviderFlashLoanExample is FlashLoan, Tokens {
     function _executeAttack() internal override {
         console.log("DAI BALANCE DURING:", EthereumTokens.DAI.balanceOf(address(this)));
         if (currentFlashLoanProvider() == FlashLoanProviders.UNISWAPV3) {
-            takeFlashLoan(FlashLoanProviders.AAVEV1, address(EthereumTokens.DAI), 1 ether);
-        } else if (currentFlashLoanProvider() == FlashLoanProviders.AAVEV1) {
+            takeFlashLoan(FlashLoanProviders.AAVEV3, address(EthereumTokens.DAI), 1 ether);
+        } else if (currentFlashLoanProvider() == FlashLoanProviders.AAVEV3) {
             // Execute attack with funds from UNISWAPV3 and AAVE
         }
     }

--- a/src/flashloan/lib/AAVEV1FlashLoan.sol
+++ b/src/flashloan/lib/AAVEV1FlashLoan.sol
@@ -2,6 +2,12 @@ pragma solidity ^0.8.0;
 
 import "forge-std/interfaces/IERC20.sol";
 
+/**
+ * @custom:deprecated
+ * @dev AAVE V1 flash loans have been disabled as part of the AAVE V1 deprecation strategy
+ * from BGD Labs. Flash loans only work from block 19168280 or earlier.
+ * https://governance.aave.com/t/temp-check-bgd-further-aave-v1-deprecation-strategy/15893/3.
+ */
 library AAVEV1FlashLoan {
     /**
      * @dev struct that hold the reference of IAAVEV1LendingPool and address core

--- a/src/flashloan/lib/EulerFlashLoan.sol
+++ b/src/flashloan/lib/EulerFlashLoan.sol
@@ -2,6 +2,12 @@ pragma solidity ^0.8.0;
 
 import "forge-std/interfaces/IERC20.sol";
 
+/**
+ * @custom:deprecated
+ * @dev Euler flash loans no longer work due to the $187M hack on March 13, 2023.
+ * Flash loans only work from block 16818068 or earlier.
+ * https://github.com/iphelix/euler-exploit-poc
+ */
 library EulerFlashLoan {
     /**
      * @dev struct that hold the reference of Euler and the dToken

--- a/test/examples/FlashLoanExample.t.sol
+++ b/test/examples/FlashLoanExample.t.sol
@@ -18,9 +18,12 @@ contract FlashLoanExampleTest is Test {
         multiProviderFlashLoanExample = new MultiProviderFlashLoanExample();
     }
 
-    function testAAVEV1FlashLoan() public {
-        flashLoanExample.initiateAttack(FlashLoanProviders.AAVEV1);
-    }
+    /**
+     * @dev Flash loans only work from block 19168280 or earlier.
+     */
+    // function testAAVEV1FlashLoan() public {
+    //     flashLoanExample.initiateAttack(FlashLoanProviders.AAVEV1);
+    // }
 
     function testAAVEV2FlashLoan() public {
         flashLoanExample.initiateAttack(FlashLoanProviders.AAVEV2);
@@ -34,6 +37,9 @@ contract FlashLoanExampleTest is Test {
         flashLoanExample.initiateAttack(FlashLoanProviders.BALANCER);
     }
 
+    /**
+     * @dev Flash loans only work from block 16818068 or earlier.
+     */
     // function testEulerFlashLoan() public {
     //     flashLoanExample.initiateAttack(FlashLoanProviders.EULER);
     // }


### PR DESCRIPTION
Fixes #39 

## Vulnerability Type
Flash loans

## Usage
Deprecated AAVEV1 and Euler flash loans

#### PR Checklist

- [X] Attack Template
- [X] Attack Example
- [X] Test
- [X] Readme Updated