### PR TITLE
Docs improvements

### DIFF
--- a/pocs/DFXFinanceBugfixReview.sol
+++ b/pocs/DFXFinanceBugfixReview.sol
@@ -37,7 +37,7 @@ contract DFXFinanceBugfixReview is PoC {
         uint256 maxBaseAmount = 7992005633260983540235600000000;
         uint256 deadline = 1676706352308;
 
-        // Deposit small amount in a loop 10,000 times to gain curve LP tokens without depositing EURS
+        // Deposit a small amount in a loop 10,000 times to gain curve LP tokens without depositing EURS
         // If gas price is 231 wei = 0.000000231651787155 => Gas = 161 matic
         console.log("Deposit small amount to curve pool 10,000 times");
         for (uint256 i = 0; i < 10000; i++) {

--- a/pocs/HundredFinanceHack.sol
+++ b/pocs/HundredFinanceHack.sol
@@ -46,7 +46,7 @@ contract HundredFinanceHack is FlashLoan, Reentrancy, PoC {
                 borrowedXdai = true;
                 uint256 amount = (totalFlashloaned * 1e12) * 60 / 100;
 
-                // Borrow xdai agaist the same usdc collateral, since the initial borrow transaction hasn't completed
+                // Borrow xdai agaist the same usdc collateral, since the initial borrow transaction hasn't been completed
                 // we can reuse the collateral
                 ICompoundToken(address(hxdai)).borrow(amount);
             }

--- a/src/flashloan/README.md
+++ b/src/flashloan/README.md
@@ -89,7 +89,7 @@ This template is for getting started with attack PoCs which use flash loans. The
 </details>
 
 ## Usage
-The following attack contract demonstrate simple flash loan usage.
+The following attack contract demonstrates simple flash loan usage.
 * [FlashLoanExample](./examples/FlashLoanExample.sol)
 
 

--- a/src/flashloan/lib/AAVEV1FlashLoan.sol
+++ b/src/flashloan/lib/AAVEV1FlashLoan.sol
@@ -10,7 +10,7 @@ import "forge-std/interfaces/IERC20.sol";
  */
 library AAVEV1FlashLoan {
     /**
-     * @dev struct that hold the reference of IAAVEV1LendingPool and address core
+     * @dev struct that holds the reference of IAAVEV1LendingPool and address core
      */
     struct Context {
         IAAVEV1LendingPool AAVElendingPool;

--- a/src/log/README.md
+++ b/src/log/README.md
@@ -57,7 +57,7 @@ A `LogType` for every main phase of an attack vector is supported. Additionally,
 | `STEP_10` | `_setLogType(LogType.STEP_10);` |
 
 
-Automatically control the lifecicle of a phase by adding a modifier to any function:
+Automatically control the lifecycle of a phase by adding a modifier to any function:
 ```solidity
 /**
   * @dev Adding the modifier `step_1` to the "depositFunds()" function

--- a/src/pricemanipulation/README.md
+++ b/src/pricemanipulation/README.md
@@ -14,7 +14,7 @@ This template is for getting started with attack PoCs which use price manipulati
 </details>
 
 ## Usage
-The following attack contract demonstrate simple flash loan usage.
+The following attack contract demonstrates simple flash loan usage.
 * [PriceManipulationExample](./examples/PriceManipulationExample.sol)
 
 


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.